### PR TITLE
feat: add `Errors` for separating joined errors.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: build
 
 on:
   push:
@@ -10,34 +10,30 @@ jobs:
   job-test:
     name: Test
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Check out source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version-file: go.mod
-          cache: true
 
       - name: Run lint
-        uses: reviewdog/action-golangci-lint@v2
+        uses: reviewdog/action-golangci-lint@f9bba13753278f6a73b27a56a3ffb1bfda90ed71 # v2.8.0
         with:
-          fail_on_error: true
+          fail_level: warning
           go_version_file: go.mod
-          golangci_lint_flags: --timeout=5m
-
-      - name: Check oldstable
-        uses: k1LoW/oldstable@v1
-        with:
-          lax: true
 
       - name: Run tests
         run: make ci
 
       - name: Run octocov
-        uses: k1LoW/octocov-action@v1
+        uses: k1LoW/octocov-action@73d561f65d59e66899ed5c87e4621a913b5d5c20 # v1.5.0

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -14,14 +14,14 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Check out source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version-file: go.mod
           cache: true
 
       - id: run-tagpr
         name: Run tagpr
-        uses: Songmu/tagpr@v1
+        uses: Songmu/tagpr@9c294c8b7b1815a5f3b7c61d6ee6aa50ac25b030 # v1.8.4

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,19 +1,41 @@
+version: "2"
+run:
+  timeout: 2m
 linters:
-  fast: false
   enable:
-    - misspell
-    - gosec
+    - errorlint
     - godot
+    - gosec
+    - misspell
     - revive
-linters-settings:
-  errcheck:
-    check-type-assertions: true
-  misspell:
-    locale: US
-    ignore-words: []
-  revive:
-    rules:
-      - name: unexported-return
-        disabled: true
-      - name: exported
-        disabled: false
+    - funcorder
+  settings:
+    errcheck:
+      check-type-assertions: true
+    misspell:
+      locale: US
+    revive:
+      rules:
+        - name: unexported-return
+          disabled: true
+        - name: exported
+          disabled: false
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - tmpmod
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Key features of `k1LoW/errors` are:
 - Retain the stack traces once stacked as far as possible.
     - Support for [`errors.Join`](https://pkg.go.dev/errors#Join).
 - It is possible to output stack traces in structured data.
+- It is possible to separate joined errors.
 - Zero dependency
 
 ## Usage
@@ -25,7 +26,7 @@ https://go.dev/play/p/8zQvFThxI4O
 ## Difference between `errors` and `k1LoW/errors`
 
 - The behaviour of methods with the same name as the [`errors`](https://pkg.go.dev/errors) package is the same.
-- `k1LoW/errors` has [`WithStack`](https://pkg.go.dev/github.com/k1LoW/errors#WithStack) and [`StackTraces`](https://pkg.go.dev/github.com/k1LoW/errors#StackTraces) functions.
+- `k1LoW/errors` has [`WithStack`](https://pkg.go.dev/github.com/k1LoW/errors#WithStack), [`StackTraces`](https://pkg.go.dev/github.com/k1LoW/errors#StackTraces) and [`Errors`](https://pkg.go.dev/github.com/k1LoW/errors#Errors) functions.
 
 ## References
 

--- a/errors.go
+++ b/errors.go
@@ -92,6 +92,25 @@ func StackTraces(err error) stackTraces {
 	return stackTraces{errws}
 }
 
+// Errors returns all joined errors in the given error.
+func Errors(err error) []error {
+	je, ok := err.(joinError)
+	if !ok {
+		return []error{err}
+	}
+	errs := je.Unwrap()
+	var splitted []error
+	for _, e := range errs {
+		errrs := Errors(e)
+		if len(errrs) > 1 {
+			splitted = append(splitted, Errors(e)...)
+			continue
+		}
+		splitted = append(splitted, e)
+	}
+	return splitted
+}
+
 type stackTraces []*errorWithStack
 
 type errorWithStack struct {


### PR DESCRIPTION
This pull request introduces a new utility function to the `k1LoW/errors` package for splitting joined errors, updates the documentation to reflect this addition, and adds comprehensive tests to ensure correct behavior.

### New functionality

* Added a new `Errors` function to `errors.go` that recursively splits joined errors and returns all underlying errors as a flat slice.

### Documentation updates

* Updated the "Key features" list in `README.md` to mention the ability to split joined errors.
* Updated the comparison section in `README.md` to include the new `Errors` function alongside existing features.

### Testing

* Added a new `TestErrors` unit test in `errors_test.go` to verify the correct splitting of joined and nested joined errors, as well as handling of non-joined errors.