### PR TITLE
feat: add AsType with build-tag-based polyfill for Go <1.26

### DIFF
--- a/astype.go
+++ b/astype.go
@@ -1,0 +1,17 @@
+//go:build !go1.26
+
+package errors
+
+import "errors"
+
+// AsType is a polyfill for [errors.AsType] (available since Go 1.26).
+//
+// [errors.AsType]: https://pkg.go.dev/errors#AsType
+func AsType[T error](err error) (T, bool) {
+	var target T
+	if errors.As(err, &target) {
+		return target, true
+	}
+	var zero T
+	return zero, false
+}

--- a/astype_go126.go
+++ b/astype_go126.go
@@ -1,0 +1,12 @@
+//go:build go1.26
+
+package errors
+
+import "errors"
+
+// AsType is a wrapper for [errors.AsType].
+//
+// [errors.AsType]: https://pkg.go.dev/errors#AsType
+func AsType[T error](err error) (T, bool) {
+	return errors.AsType[T](err)
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -400,6 +400,56 @@ func TestConpatibility(t *testing.T) {
 	})
 }
 
+func TestAsType(t *testing.T) {
+	t.Run("match", func(t *testing.T) {
+		err := errors.Join(&testError{msg: "hello"}, errF)
+		got, ok := errors.AsType[*testError](err)
+		if !ok {
+			t.Fatal("AsType should return true")
+		}
+		if got.msg != "hello" {
+			t.Errorf("got: %s, want: %s", got.msg, "hello")
+		}
+	})
+
+	t.Run("no match", func(t *testing.T) {
+		err := errors.Join(errA, errF)
+		_, ok := errors.AsType[*testError](err)
+		if ok {
+			t.Fatal("AsType should return false")
+		}
+	})
+
+	t.Run("nil error", func(t *testing.T) {
+		_, ok := errors.AsType[*testError](nil)
+		if ok {
+			t.Fatal("AsType should return false for nil")
+		}
+	})
+
+	t.Run("wrapped", func(t *testing.T) {
+		err := fmt.Errorf("wrapped: %w", &testError{msg: "inner"})
+		got, ok := errors.AsType[*testError](err)
+		if !ok {
+			t.Fatal("AsType should return true for wrapped error")
+		}
+		if got.msg != "inner" {
+			t.Errorf("got: %s, want: %s", got.msg, "inner")
+		}
+	})
+
+	t.Run("with stack", func(t *testing.T) {
+		err := errors.WithStack(&testError{msg: "stacked"})
+		got, ok := errors.AsType[*testError](err)
+		if !ok {
+			t.Fatal("AsType should return true for error with stack")
+		}
+		if got.msg != "stacked" {
+			t.Errorf("got: %s, want: %s", got.msg, "stacked")
+		}
+	})
+}
+
 func assertFrames(t *testing.T, frames []errors.Frame, names ...string) {
 	t.Helper()
 	for i, name := range names {


### PR DESCRIPTION
Add errors.AsType generic function that wraps errors.AsType from Go 1.26. For Go <1.26, a polyfill using errors.As is provided via build tags.